### PR TITLE
Add *.mediawiki detection as filetype=mediawiki

### DIFF
--- a/ftdetect/mediawiki.vim
+++ b/ftdetect/mediawiki.vim
@@ -1,5 +1,6 @@
 if has("autocmd")
   au BufRead,BufNewFile *.wiki           set filetype=mediawiki
+  au BufRead,BufNewFile *.mediawiki      set filetype=mediawiki
   au BufRead,BufNewFile *.wikipedia.org* set filetype=mediawiki
   au BufRead,BufNewFile *.wikibooks.org* set filetype=mediawiki
   au BufRead,BufNewFile *.wikimedia.org* set filetype=mediawiki


### PR DESCRIPTION
Seems a natural enough thing to add. I use pandoc to generate lots of different kinds of wiki output, so .wiki extension isn't very useful.

Thanks for the repo,
 -Gavin
