### PR TITLE
Add .mw file extension to ftdetect

### DIFF
--- a/ftdetect/mediawiki.vim
+++ b/ftdetect/mediawiki.vim
@@ -1,4 +1,5 @@
 if has("autocmd")
+  au BufRead,BufNewFile *.mw             set filetype=mediawiki
   au BufRead,BufNewFile *.wiki           set filetype=mediawiki
   au BufRead,BufNewFile *.mediawiki      set filetype=mediawiki
   au BufRead,BufNewFile *.wikipedia.org* set filetype=mediawiki


### PR DESCRIPTION
Would be nice to have mediawiki.vim detect .mw files as MediaWiki ones.
This extension is used by Git-MediaWiki (https://github.com/moy/Git-Mediawiki/wiki).
