### PR TITLE
Template and README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ setlocal fdm=expr
 
 ### Credits, licence
 
-See comments within `syntax/vim-mediawiki.vim`. Basically this is public domain.
+See comments within `syntax/mediawiki.vim`. Basically this is public domain.
 
-Thanks to folks at http://en.wikipedia.org/wiki/Wikipedia:Text_editor_support!
+Thanks to folks at http://en.wikipedia.org/wiki/Wikipedia:Text_editor_support !
 
 Static releases available at http://www.vim.org/scripts/script.php?script_id=3970.
 

--- a/syntax/mediawiki.vim
+++ b/syntax/mediawiki.vim
@@ -188,7 +188,7 @@ sy region wikiLink start="\[gopher:" end="\]" oneline contains=wikiNowiki,wikiNo
 sy region wikiLink start="\[news:"   end="\]" oneline contains=wikiNowiki,wikiNowikiEndTag
 sy region wikiLink start="\[mailto:" end="\]" oneline contains=wikiNowiki,wikiNowikiEndTag
 
-sy match  wikiTemplateName /{{\s*\w\+/hs=s+2 contained
+sy match  wikiTemplateName /{{[^{|}<>\[\]]\+/hs=s+2 contained
 sy region wikiTemplate start="{{" end="}}" keepend extend contains=wikiNowiki,wikiNowikiEndTag,wikiTemplateName,wikiTemplateParam,wikiTemplate,wikiLink
 sy region wikiTemplateParam start="{{{\s*\d" end="}}}" extend contains=wikiTemplateName
 


### PR DESCRIPTION
The template name regex is a bit better, detecting template names that have whitespace and symbols, which it did not do before. Also, fixed a reference to a file in the README.
